### PR TITLE
Fix oauth2 arguments error

### DIFF
--- a/gmail_cli/util.py
+++ b/gmail_cli/util.py
@@ -30,7 +30,9 @@ def get_credentials(appname, secret_file, scopes=DEFAULT_SCOPES):
     if not credentials or credentials.invalid:
         flow = oauth2client.client.flow_from_clientsecrets(secret_file, scopes)
         flow.user_agent = appname
-        credentials = oauth2client.tools.run_flow(flow, store)
+        oauth2args = '--auth_host_name localhost --logging_level INFO'.split()
+        flags = oauth2client.tools.argparser.parse_args(oauth2args)
+        credentials = oauth2client.tools.run_flow(flow, store, flags)
 
     return credentials
 


### PR DESCRIPTION
If you don't pass in flags, the oauth2 libarary expects options on the command
\line.  It will parse the command line arguments and fail because it expects
different arguments from the script calling the oauth2 flow functions.

See https://stackoverflow.com/questions/25271385/error-unrecognized-arguments-shell-oauth-2-0-google-apis-client-for-python#25583562.